### PR TITLE
Add ability to download X100F configuration backup.

### DIFF
--- a/examples/fuji/recv.py
+++ b/examples/fuji/recv.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.path.insert(0, './ptpy')
+
+from ptpy import PTPy
+
+camera = PTPy(knowledge=False)
+
+print(camera.get_device_info());
+ 
+with camera.session():
+    camera.get_config_info()
+    with open("config.dat", "wb") as file:
+        file.write(camera.get_config_backup().Data)

--- a/examples/fuji/send.py
+++ b/examples/fuji/send.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.path.insert(0, './ptpy')
+
+from ptpy import PTPy
+
+camera = PTPy(knowledge=False)
+
+print(camera.get_device_info());
+ 
+with camera.session():
+    object_info = camera.get_config_info().Data
+    camera.send_object_info(object_info)
+
+    with open("config.dat", "rb") as file:
+        print(camera.send_object(file.read()))

--- a/ptpy/__init__.py
+++ b/ptpy/__init__.py
@@ -5,6 +5,7 @@ from .extensions.microsoft import Microsoft
 from .extensions.parrot import Parrot
 from .extensions.nikon import Nikon
 from .extensions.sony import Sony
+from .extensions.fujix100 import FujiX100
 from .ptp import PTP, PTPError
 from .transports.usb import USBTransport as USB
 from .transports.ip import IPTransport as IP
@@ -40,6 +41,7 @@ __all__ = (
     'Microsoft',
     'Nikon',
     'Sony',
+    'FujiX100',
     # Transports
     'IP',
     'USB',
@@ -66,6 +68,7 @@ known_extensions = {
     'FotoNation': None,
     'PENTAX': None,
     'Fuji': None,
+    'FujiX100': FujiX100,
     'Sony': Sony,
     'Samsung': None,
     'Parrot': Parrot,

--- a/ptpy/extensions/fujix100.py
+++ b/ptpy/extensions/fujix100.py
@@ -1,0 +1,54 @@
+from contextlib import contextmanager
+from construct import Container, Struct, Range, Computed, Enum, Array, PrefixedArray, Pass, ExprAdapter
+from ..ptp import PTPError
+import logging
+logger = logging.getLogger(__name__)
+
+__all__ = ('FujiX100',)
+
+class FujiX100Error(PTPError):
+    pass
+
+class FujiX100(object):
+    '''This class implements FujiX100's PTP operations.'''
+    def __init__(self, *args, **kwargs):
+        logger.debug('Init FujiX100')
+        super(FujiX100, self).__init__(*args, **kwargs)
+
+    @contextmanager
+    def session(self):
+        with super(FujiX100, self).session():
+            yield
+
+    def get_config_info(self):
+        '''Returns the configuration object info
+
+        Perform GetObject request with the handle set to 0.
+        The PTP spec says that requesting this is undefined but Fuji appear
+        to be using it as a way of getting the config backup.
+
+        This should be called before getting the object or you will get an authorisation error.
+        '''
+        ptp = Container(
+            OperationCode='GetObjectInfo',
+            SessionID=self._session,
+            TransactionID=self._transaction,
+            Parameter=[0]
+        )
+        response = self.recv(ptp)
+        return response
+
+    def get_config_backup(self):
+        '''Returns the configuration backup as binary string.
+
+        Perform GetObject request with the handle set to 0.
+        The PTP spec says that requesting this is undefined but Fuji appear
+        to be using it as a way of getting the config backup.
+        '''
+        ptp = Container(
+            OperationCode='GetObject',
+            SessionID=self._session,
+            TransactionID=self._transaction,
+            Parameter=[0]
+        )
+        return self.recv(ptp)

--- a/ptpy/ptp.py
+++ b/ptpy/ptp.py
@@ -333,7 +333,8 @@ class PTP(object):
             Agilent=0x00000003,
             Polaroid=0x00000004,
             AgfaGevaert=0x00000005,
-            Microsoft=0x00000006,
+            FujiX100=0x00000006,
+            # MicroSoft=0x00000006, # TODO: Fuji X100 appears to be reporting with this ID?
             Equinox=0x00000007,
             Viewquest=0x00000008,
             STMicroelectronics=0x00000009,


### PR DESCRIPTION
Fuji have their "Aquire" software which allows you to backup and restore
configuration data. However it only works on Windows and OS X :(

After some sniffing of the USB traffic it seems, at least for the backup
part, to be using standard(ish) ObjectGet request but with a handle of
`0` (which is undefined according to the spec)

The catch is that when performing the GetObjectInfo request the ptpy
fails to parse the response as it contains a null date.

Lets create an extension to house as much of our custom/hacky code as
possible :)

## Usage
```python
#!/usr/bin/env python3

import sys

sys.path.insert(0, './ptpy')

from ptpy import PTPy

camera = PTPy(knowledge=False)

print(camera.get_device_info());

with camera.session():
    camera.get_config_info()
    with open("config.dat", "wb") as file:
        file.write(camera.get_config_backup().Data)
```